### PR TITLE
Allow use of `db.join*` methods more than once

### DIFF
--- a/internal/util/db/join.go
+++ b/internal/util/db/join.go
@@ -14,7 +14,7 @@ func InnerJoinWithFilter(baseTable string, baseColumn string, joinTable string, 
 		filterTable = optFilterTable[0]
 	}
 
-	return qm.InnerJoin(fmt.Sprintf("%s ON %s.%s=%s.%s AND %s.%s=$1",
+	return qm.InnerJoin(fmt.Sprintf("%s ON %s.%s=%s.%s AND %s.%s=?",
 		joinTable,
 		joinTable,
 		joinColumn,
@@ -52,7 +52,7 @@ func LeftOuterJoinWithFilter(baseTable string, baseColumn string, joinTable stri
 		filterTable = optFilterTable[0]
 	}
 
-	return qm.LeftOuterJoin(fmt.Sprintf("%s ON %s.%s=%s.%s AND %s.%s=$1",
+	return qm.LeftOuterJoin(fmt.Sprintf("%s ON %s.%s=%s.%s AND %s.%s=?",
 		joinTable,
 		joinTable,
 		joinColumn,


### PR DESCRIPTION
The `db.InnerJoinWithFilter` and `db.LeftOuterJoinWithFilter` methods use `$1` when building the join string, so using any of them more than once fails because of invalid parameters.